### PR TITLE
Updated Chunk support & Fixes

### DIFF
--- a/CCSF/CCS.bt
+++ b/CCSF/CCS.bt
@@ -16,6 +16,8 @@
 #include "CCS_Types.bt"
 #include "CCS_AnmStructs.bt"
 #include "CCS_Animation.bt"
+#include "CCS_PartStructs.bt"
+#include "CCS_Particle.bt"
 #include "CCS_Stream.bt"
 
 local u32 ccsfColor = SetRandomBackColor();
@@ -135,7 +137,7 @@ typedef struct
     u32 ShadowID <read=ReadChunkNameIndex>;
 
     local u32 CurVersion = CCSF.Version;
-    if (CurVersion > 0x120)
+    if (CurVersion > 0x120 && DataSize != 4)
     {
         u32 Extra <read=ReadChunkNameIndex>;
     }
@@ -162,9 +164,83 @@ typedef struct
     float Alpha;
     if (CCSF.Version > 0x120)
     {
-        float OffsetX;
-        float OffsetY;
-        u8 data[(DataSize * 4) - 0x14];
+        //float OffsetX;
+        //float OffsetY;
+		
+		if (CCSF.Version > 0x130)
+		{
+            //float OffsetX;
+            //float OffsetY;
+            s16 OffsetX <read = (this / 4096.0)>;
+            s16 OffsetY <read = (this / 4096.0)>;
+            s16 scaleX  <read = (this / 4096.0)>;
+            s16 scaleY  <read = (this / 4096.0)>;
+            
+			struct {
+			    u8	u8_Unk_00; //have only seen as 0xFF
+			    u8	u8_Unk_01; //have only seen as 0x00
+			    u8	u8_Unk_02; //have only seen as 0x00
+			    u8	u8_Unk_03; //have only seen as 0x80
+			    u32	u32_Unk_04;
+			
+			    struct
+			    {
+				    u8 R;
+				    u8 G;
+				    u8 B;
+				    u8 A;
+			    }AmbientColor;
+			
+			    u32	Texture02Index <read=ReadChunkNameIndex>;
+			    float	NormalMapParam;
+			    u32		u32_Unk_05;
+			    u32		Texture03Index <read=ReadChunkNameIndex>;
+			    float	SpecularParam_Y;
+			    float	SpecularParam_X;
+			    u32		Texture04Index <read=ReadChunkNameIndex>;
+			    u8      MultiTexParam_Y;
+			    u8      u32_Unk_6;
+			    u8      MultiTexParam_Z;
+			    u8      u32_Unk_7;
+			
+			    struct
+			    {
+				    float MultiTexUV_X;
+				    float MultiTexUV_Y;
+				    float MultiTexUV_Z;
+				    float MultiTexUV_W;
+			    }MultiTexUV;
+                
+			    float	MultiTexSpeed_X;
+			    float	MultiTexSpeed_Y;
+			
+			    struct
+			    {
+				    u8 R;
+				    u8 G;
+				    u8 B;
+				    u8 A;
+			    }EmissionColor;
+			} data_gen3_1;
+		}
+		else if (CCSF.Version == 0x130)
+		{
+            //float OffsetX;
+            //float OffsetY;
+            s16 OffsetX <read = (this / 4096.0)>;
+            s16 OffsetY <read = (this / 4096.0)>;
+            s16 scaleX  <read = (this / 4096.0)>;
+            s16 scaleY  <read = (this / 4096.0)>;
+			u32 data_gen3_0[9];
+		}
+		else
+		{
+            s16 OffsetX <read = (this / 4096.0)>;
+            s16 OffsetY <read = (this / 4096.0)>;
+            s16 scaleX  <read = (this / 4096.0)>;
+            s16 scaleY  <read = (this / 4096.0)>;
+			u8 data[(DataSize * 4) - 0x14];
+		}
     }
     else
     {
@@ -175,7 +251,7 @@ typedef struct
     
 }MAT;
 
-//Material Chunk
+//Camera Chunk
 typedef struct
 {   
     SetBackColor( SetRandomBackColor() );
@@ -212,9 +288,12 @@ typedef struct
         u16 TexWidth;
         u16 TexHeight;
     }
-    else if (TextureType == 0x87|| TextureType == 0x89)
+    else if (TextureType == 0x87|| TextureType == 0x88|| TextureType == 0x89)
     {
-        FSkip(0x10);
+        FSkip(0x04);
+        u32 TextureDataSizeBTX;
+        FSkip(0x08);
+        //FSkip(0x10);
         u16 TexWidth;
         u16 TexHeight;
         FSkip(0x14);
@@ -226,23 +305,36 @@ typedef struct
     
     u32 TextureDataSize;
     
-    if (TextureType == 0x87|| TextureType == 0x89)
+    if (TextureType == 0x87|| TextureType == 0x88|| TextureType == 0x89)
     {
-        local u32 TexDataSize = TextureDataSize - 0x40;
+        local u32 TexDataSize = TextureDataSizeBTX - 0x40;
         FSkip(0x0C);
         char TextureName[16];
     }
     else
     {
         local u32 TexDataSize = TextureDataSize << 2;
+        
     }
     
    u8 Pixels[TexDataSize];
+   
+    if (MipMapsCount > 0)
+    {
+        struct
+            {
+            u32 MipMap_Unk4;
+            u32 MipMap_DataSize;
+            u8 MipMap_Pixaks[MipMap_DataSize * 4];
+        }MipMaps[MipMapsCount] <optimize=false>;
+            
+    }
     
     /*if (TextureType == 0)
     {
         Printf("Texture found at %d", ChunkNameIndex);
     }*/
+    
 
 }TEX;
 
@@ -251,7 +343,7 @@ typedef struct
 {   
     SetBackColor( ColorPaletteSectionColor );
     u32 ChunkNameIndex <read=ReadChunkNameIndex>;
-    u32 BlitGroup;
+    u32 BlitGroupID <read=ReadChunkNameIndex>;
     FSkip(8);
     u32 ColorCount;
     local int i;
@@ -279,7 +371,9 @@ typedef struct
     u8 SourceFactor;
     u8 DestinationFactor;
     s16 UnkFlags;
-    u32 LookupCount;
+    u8 LookupCount;
+    u8 unk1;
+    u16 TangentBinormalFlag;
     local u32 CurVersion = CCSF.Version;
     if (CurVersion > 0x110)
     {
@@ -319,9 +413,9 @@ typedef struct
                     struct
                     {
 
-                        s8 vnX;
-                        s8 vnY;
-                        s8 vnZ;
+                        s8 vnX <read= Str("%f , %d", this / 64.0, this)>;
+                        s8 vnY <read= Str("%f , %d", this / 64.0, this)>;
+                        s8 vnZ <read= Str("%f , %d", this / 64.0, this)>;
 
                         u8 triFlag;
                     }VertsNormals[VertexCount];
@@ -343,16 +437,35 @@ typedef struct
                         {
                             if(CCSF.Version >= 0x125)
 					        {
-						        u32 U;
-                                u32 V;
+						        s32 U <read= Str("%f , %d", this / 65536.0, this)>;
+                                s32 V <read= Str("%f , %d", this / 65536.0, this)>;
 					        }
 					        else
 					        {
-                                s16 U;
-                                s16 V;					            
+                                s16 U <read= Str("%f , %d", this / 256.0, this)>;
+                                s16 V <read= Str("%f , %d", this / 256.0, this)>;					            
                             }
                         }UVCoords[VertexCount] <optimize = true>;
                     }
+					
+					if (TangentBinormalFlag == 1)
+					{
+						struct
+						{
+							s8 vtX <read= Str("%f , %d", this / 64.0, this)>;
+							s8 vtY <read= Str("%f , %d", this / 64.0, this)>;
+							s8 vtZ <read= Str("%f , %d", this / 64.0, this)>;
+							u8 Flag;
+						} VertsTangernts[VertexCount];
+										
+						struct
+						{
+							s8 vbX <read= Str("%f , %d", this / 64.0, this)>;
+							s8 vbY <read= Str("%f , %d", this / 64.0, this)>;
+							s8 vbZ <read= Str("%f , %d", this / 64.0, this)>;
+							u8 Flag;
+						} VertsBinormals[VertexCount];
+					}
                 }Mesh;
             }
         }
@@ -439,157 +552,198 @@ typedef struct
             
             local int m, i, v;
             for (m = 0; m < MeshCount; m++)
-            {
-                struct
-                {
-                    u32 MatTexID <read=ReadChunkNameIndex>;
-                    u32 VertexCount;
-                    u32 Unk;
-                    u32 ParentID; // from lookup list
-        
-                    struct
-                    {
-                        s16 X;
-                        s16 Y;
-                        s16 Z;
-                    } VertexPositions[VertexCount];
-        
-                    if ((FTell() % 4) == 2)
-                    {
-                        u16 Padding;
-                    }
-        
-                    struct
-                    {
-                        u8 vnX;
-                        u8 vnY;
-                        u8 vnZ;
-                        u8 triFlag;
-                    } VertsNormals[VertexCount];
-        
-                    struct
-                    {
-                        if (CCSF.Version >= 0x125)
-                        {
-                            s32 U;
-                            s32 V;
-                        }
-                        else
-                        {
-                            s16 U;
-                            s16 V;
-                        }
-                    } UVCoords[VertexCount] <optimize = true>;
-                } Mesh;
-                
-                if (m+2 >= MeshCount)
-                {
-                    break;
-                }
-            }
+            {	
+				struct
+				{
+					u32 MatTexID <read=ReadChunkNameIndex>;
+					u32 VertexCount;
+					u32 DeformableVerts;
+					
+					if (DeformableVerts == 0)
+					{
+						struct
+						{
+							u32 ParentID; // from lookup list
+				
+							struct
+							{
+								s16 X;
+								s16 Y;
+								s16 Z;
+							} VertexPositions[VertexCount];
+				
+							if ((FTell() % 4) == 2)
+							{
+								u16 Padding;
+							}
+				
+							struct
+							{
+								s8 vnX <read= (this / 64.0)>;
+								s8 vnY <read= (this / 64.0)>;
+								s8 vnZ <read= (this / 64.0)>;
+								u8 triFlag;
+							} VertsNormals[VertexCount];
+				
+							struct
+							{
+								if (CCSF.Version >= 0x125)
+								{
+									s32 U;
+									s32 V;
+								}
+								else
+								{
+									s16 U;
+									s16 V;
+								}
+							} UVCoords[VertexCount] <optimize = true>;
+							
+							if (TangentBinormalFlag == 1)
+							{
+								struct
+								{
+									s8 vtX <read= (this / 64.0)>;
+									s8 vtY <read= (this / 64.0)>;
+									s8 vtZ <read= (this / 64.0)>;
+									u8 Flag;
+								} VertsTangernts[VertexCount];
+								
+								struct
+								{
+									s8 vbX <read= (this / 64.0)>;
+									s8 vbY <read= (this / 64.0)>;
+									s8 vbZ <read= (this / 64.0)>;
+									s8 Flag;
+								} VertsBinormals[VertexCount];
+							}
+				
+						} Mesh;
+					}
             
-            if (LookupCount > 1)
-            {
-                struct
-                {
-                    u32 MatTexID <read=ReadChunkNameIndex>;
-                    u32 VertexCount;
-                    u32 DeformableVerts;
-            
-                    if (CCSF.Version < 0x125)
-                    {
-                        local int t;
-            
-                        struct
-                        {
-                            s16 X;
-                            s16 Y;
-                            s16 Z;
-                            u16 Params;
-                            local int dualFlag = ((Params >> 9) & 0x1) == 0;
-            
-                            if (dualFlag)
-                            {
-                                s16 X2;
-                                s16 Y2;
-                                s16 Z2;
-                                u16 Params2;
-                            }
-                        } VertexPosition[VertexCount] <optimize = false>;
-            
-                        if ((FTell() % 4) == 2)
-                        {
-                            u16 Padding;
-                        }
-            
-                        struct
-                        {
-                            u8 vnX;
-                            u8 vnY;
-                            u8 vnZ;
-                            u8 triFlag;
-                        } VertsNormals[DeformableVerts];
-            
-                        struct
-                        {
-                            if (CCSF.Version >= 0x125)
-                            {
-                                u32 U;
-                                u32 V;
-                            }
-                            else
-                            {
-                                u16 U;
-                                u16 V;
-                            }
-                        } UVCoords[VertexCount] <optimize = true>;
-                    }
-                    else if (ModelType == 6)
-                    {
-                        if (CurVersion > 0x111)
-                        {
-                            u8 LookupList[LookupCount] <read=ReadChunkNameLookup>;
-                        }
-                        if ((FTell() % 4) != 0)
-                        {
-                            local u32 PadSize = 4 - (FTell() % 4);
-                            FSkip(PadSize);
-                        }
-                    }
-                    else
-                    {
-                        // GEN3
-                        struct
-                        {
-                            s16 X;
-                            s16 Y;
-                            s16 Z;
-                            u16 Weight;
-                            u16 StopBit;
-                            u16 BoneID;
-                        } VertexPositions[DeformableVerts];
-            
-                        if ((FTell() % 4) == 2)
-                        {
-                            u16 Padding;
-                        }
-            
-                        struct
-                        {
-                            u8 vnX;
-                            u8 vnY;
-                            u8 vnZ;
-                            u8 triFlag;
-                        } VertsNormals[DeformableVerts];
-            
-                        struct
-                        {
-                            u32 U;
-                            u32 V;
-                        } UVCoords[VertexCount];
-                    }
-                } DeformableMesh;
-            }
+					if (LookupCount > 1)
+					{
+						if (DeformableVerts != 0)
+						{
+							struct
+							{
+						
+								if (CCSF.Version < 0x125)
+								{
+									local int t;
+						
+									struct
+									{
+										s16 X;
+										s16 Y;
+										s16 Z;
+										u16 Params;
+										local int dualFlag = ((Params >> 9) & 0x1) == 0;
+						
+										if (dualFlag)
+										{
+											s16 X2;
+											s16 Y2;
+											s16 Z2;
+											u16 Params2;
+										}
+									} VertexPosition[VertexCount] <optimize = false>;
+						
+									if ((FTell() % 4) == 2)
+									{
+										u16 Padding;
+									}
+						
+									struct
+									{
+										u8 vnX;
+										u8 vnY;
+										u8 vnZ;
+										u8 triFlag;
+									} VertsNormals[DeformableVerts];
+						
+									struct
+									{
+										if (CCSF.Version >= 0x125)
+										{
+											u32 U;
+											u32 V;
+										}
+										else
+										{
+											u16 U;
+											u16 V;
+										}
+									} UVCoords[VertexCount] <optimize = true>;
+								}
+								else if (ModelType == 6)
+								{
+									if (CurVersion > 0x111)
+									{
+										u8 LookupList[LookupCount] <read=ReadChunkNameLookup>;
+									}
+									if ((FTell() % 4) != 0)
+									{
+										local u32 PadSize = 4 - (FTell() % 4);
+										FSkip(PadSize);
+									}
+								}
+								else
+								{
+									// GEN3
+									struct
+									{
+										s16 X;
+										s16 Y;
+										s16 Z;
+										u16 Weight;
+										u16 StopBit;
+										u16 BoneID;
+									} VertexPositions[DeformableVerts];
+						
+									if ((FTell() % 4) == 2)
+									{
+										u16 Padding;
+									}
+						
+									struct
+									{
+										s8 vnX <read= Str("%f , %d", this / 64.0, this)>;
+										s8 vnY <read= Str("%f , %d", this / 64.0, this)>;
+										s8 vnZ <read= Str("%f , %d", this / 64.0, this)>;
+										u8 triFlag;
+									} VertsNormals[DeformableVerts];
+						
+									struct
+									{
+										u32 U;
+										u32 V;
+									} UVCoords[VertexCount];
+							
+									if (TangentBinormalFlag == 1)
+									{
+										struct
+										{
+											s8 vtX <read= Str("%f , %d", this / 64.0, this)>;
+											s8 vtY <read= Str("%f , %d", this / 64.0, this)>;
+											s8 vtZ <read= Str("%f , %d", this / 64.0, this)>;
+											u8 Flag;
+										} VertsTangernts[DeformableVerts];
+										
+										struct
+										{
+											s8 vbX <read= Str("%f , %d", this / 64.0, this)>;
+											s8 vbY <read= Str("%f , %d", this / 64.0, this)>;
+											s8 vbZ <read= Str("%f , %d", this / 64.0, this)>;
+											u8 Flag;
+										} VertsBinormals[DeformableVerts];
+									}
+								}
+							} DeformableMesh;
+						}
+					}
+				} SubModel;
+			}
         }
         //Shadow Models
         else if (ModelType == ShadowMesh)
@@ -829,6 +983,37 @@ typedef struct
     u32 Unk;
 }LIT;
 
+//Blit Chunk
+typedef struct
+{
+    local uint ChunkNameIndex = 0;
+    u8 Data[(DataSize * 4)];
+}BLT;
+
+//EffectChunk
+typedef struct
+{
+    u32 ChunkNameIndex <read=ReadChunkNameIndex>;
+    u32 TextureIndex <read=ReadChunkNameIndex>;
+    u16 unk1;
+    u16 unk2;
+    u16 unk3;
+    u16 Count;
+    float unk;
+    float unk;
+    float unk;
+    float unk;
+    u16 TexTile_X <read = (this / 4096.0)>;
+    u16 TexTile_Y <read = (this / 4096.0)>;
+    
+    struct
+    {
+    u16 Offset_X  <read = (this / 4096.0), comment="Horizontal">;
+    u16 Offset_Y  <read = (this / 4096.0), comment="Vertical">;
+    u16 TexTile_Opacity  <read = (this / 8192.0)>;
+    s16 A;
+    } TexTile_Frames[Count];
+}EFF;
 
 //Unknown Chunk
 typedef struct
@@ -878,6 +1063,17 @@ typedef struct
         case Bounding_Box:
             struct BOX Chunk;
             break;
+        case Effect:
+            struct EFF Chunk;
+            break;
+            
+        case PartAnmCtrl:
+            struct PAC Chunk;
+            break;
+        case PartGenerator:
+            struct PGE Chunk;
+            break;
+            
         case Dummy_Position:
             struct DMY Chunk;
             break;
@@ -920,6 +1116,9 @@ typedef struct
         case Light:
             struct LIT Chunk;
             break;
+        case Blit_Group:
+            struct BLT Chunk;
+            break;
         
         default:
             struct UNK Chunk;
@@ -929,7 +1128,6 @@ typedef struct
         
   
 } TChunk <read= ReadChunkName>;
-
 
 
 string ReadTString(TString& value )
@@ -957,9 +1155,16 @@ string ReadChunkNameIndex(u32& value )
 string ReadChunkNameSIndex(s32 & value )
 {
     local string str = "";
-    local string Name = CCSF.StringTable.Names.ChunkName[value].Data;
-    local int Index = value;
-    SPrintf(str, "%s (Index %d)", Name , Index);
+	if (value >= 0)
+	{
+		local string Name = CCSF.StringTable.Names.ChunkName[value].Data;
+		local int Index = value;
+		SPrintf(str, "%s (Index %d)", Name , Index);
+	}
+	else
+	{
+		SPrintf(str, "null");
+	}
 }
 
 string ReadChunkNameLookup(u8 & value )
@@ -1041,6 +1246,10 @@ string ReadAnmChunkType(AnimationTypes & value)
         case 0x1901:
             str = "MorphKeyframe";
         break;
+        
+        case 0x1902:
+            str = "MorpherController";
+        break;
 
         case 0x1A01:
             str = "OutlineFrame";
@@ -1053,7 +1262,28 @@ string ReadAnmChunkType(AnimationTypes & value)
         case 0x1D01:
             str = "FBSBlurFrame";
         break;
+    }
+    
+    return str;
+}
+
+string ReadPartGenChunkType(PartGeneratorTypes & value)
+{
+    local string str = "";
+
+    switch (value)
+    {
+        case 0xffff:
+            str = "0xFFFF";
+        break;
         
+        case 0x0000:
+            str = "0x0000";
+        break;
+        
+        case 0x00fd:
+            str = "0x00FD";
+        break;
     }
     
     return str;

--- a/CCSF/CCS_Animation.bt
+++ b/CCSF/CCS_Animation.bt
@@ -77,7 +77,7 @@ typedef struct
                     struct DistantLFrame Distant;
                 break;
                 
-                case DirectionalLightController:
+                case DistantLightController:
                     struct DistantLCtrl DistantLController;
                 break;
 

--- a/CCSF/CCS_Animation.bt
+++ b/CCSF/CCS_Animation.bt
@@ -58,7 +58,7 @@ typedef struct
                     struct MorphFrame MorpherFrame;
                 break;
                 case MorpherController:
-                    struct MorphCtrl MorphController;
+                    struct MorphCtrl MorpherController;
                 break;
 
                 case NoteFrame:
@@ -75,6 +75,10 @@ typedef struct
                 
                 case DistantLightFrame:
                     struct DistantLFrame Distant;
+                break;
+                
+                case DirectionalLightController:
+                    struct DistantLCtrl DistantLController;
                 break;
 
                 case ShadowFrame:
@@ -109,7 +113,8 @@ typedef struct
                     Printf("Unknown Animation (%x) at %x\n", Type, FTell());
                     struct
                         {
-                            u8 Data [Size * 4];
+                            //u8 Data [Size * 4];
+                            u8 Data [EndPos - FTell()];
                         }SUnknown;
                 break;
             }

--- a/CCSF/CCS_AnmStructs.bt
+++ b/CCSF/CCS_AnmStructs.bt
@@ -33,7 +33,14 @@ typedef struct
     {
         f32 Intensity;
     }
-}DistantLFrame; 
+}DistantLFrame;
+
+
+typedef struct
+{
+    u32 Index <read= ReadChunkNameIndex>;
+    u32 Data[Size - 1];
+}DistantLCtrl;
 
 
 typedef struct
@@ -112,16 +119,40 @@ typedef struct
 typedef struct
 {
     u32 Index <read= ReadChunkNameIndex>;
-    u32 Flags;
-    u32 TargetModel <read= ReadChunkNameIndex>;
-    u32 Unk;
+    u32 Count;
+    //u32 Flags;
+    //u32 TargetModel <read= ReadChunkNameIndex>;
+    //u32 Unk;
+    //u32 Frames;
     //u32 Frames;
     
+    //struct{
+    //    u32 Frame;
+    //    float Value;
+    //}MorphFCtrl[Frames];
+    
+    
     struct{
-        u32 Frame;
-        float Value;
-    }MorphFCtrl[Frames];
-
+        u32 MorphIndex;
+        u32 ctrlFlags;
+        
+        if ((ctrlFlags & 7) == 2) 
+        {
+            u32 frameCount;
+            
+            struct{
+                s32     key;
+                float   value;
+            }FrameValues[frameCount];
+        }
+        else if ((ctrlFlags & 7) == 1) 
+        {
+            float FrameValue;
+        }
+        
+    }MorphTarget[Count] <optimize=false>;
+    
+    //u8 data[(Size * 4) - 8];
     
 }MorphCtrl;
 
@@ -130,6 +161,8 @@ typedef struct
 {
     u32 Index <read= ReadChunkNameIndex>;
     u32 Flags;
+    //u16 Flags;
+    //u16 C;
     struct{
         AnmCtrlFloat(Flags);
     }OffsetX;
@@ -142,6 +175,23 @@ typedef struct
     struct{
         AnmCtrlFloat(Flags >> 9);
     }ScaleY;
+    
+    //Unknown
+    struct{
+        AnmCtrlFloat(Flags >> 12);
+    }OffsetA;
+    struct{
+        AnmCtrlFloat(Flags >> 15);
+    }OffsetB;
+    
+    //if (Size == 52)
+    //{
+    //    u8 data[(Size * 4) - 112];
+    //}
+    //if (Size == 36)
+    //{
+    //    u8 data[(Size * 4) - 80];
+    //}
     
 }MatCtrl;
 
@@ -359,7 +409,9 @@ void AnmCtrlFloat(u16 EntryType)
 {
     if ((EntryType & 7) == 2)
     {
-        u32 FrameCount;
+        u16 FrameCount;
+        u16 FrameCount00;
+        
         local int i;
         for (i = 0; i < FrameCount; i++)
         {

--- a/CCSF/CCS_AnmStructs.bt
+++ b/CCSF/CCS_AnmStructs.bt
@@ -120,17 +120,6 @@ typedef struct
 {
     u32 Index <read= ReadChunkNameIndex>;
     u32 Count;
-    //u32 Flags;
-    //u32 TargetModel <read= ReadChunkNameIndex>;
-    //u32 Unk;
-    //u32 Frames;
-    //u32 Frames;
-    
-    //struct{
-    //    u32 Frame;
-    //    float Value;
-    //}MorphFCtrl[Frames];
-    
     
     struct{
         u32 MorphIndex;
@@ -152,8 +141,6 @@ typedef struct
         
     }MorphTarget[Count] <optimize=false>;
     
-    //u8 data[(Size * 4) - 8];
-    
 }MorphCtrl;
 
 
@@ -161,8 +148,6 @@ typedef struct
 {
     u32 Index <read= ReadChunkNameIndex>;
     u32 Flags;
-    //u16 Flags;
-    //u16 C;
     struct{
         AnmCtrlFloat(Flags);
     }OffsetX;
@@ -179,19 +164,10 @@ typedef struct
     //Unknown
     struct{
         AnmCtrlFloat(Flags >> 12);
-    }OffsetA;
+    }Offset_Unknown00;
     struct{
         AnmCtrlFloat(Flags >> 15);
-    }OffsetB;
-    
-    //if (Size == 52)
-    //{
-    //    u8 data[(Size * 4) - 112];
-    //}
-    //if (Size == 36)
-    //{
-    //    u8 data[(Size * 4) - 80];
-    //}
+    }Offset_Unknown01;
     
 }MatCtrl;
 
@@ -410,7 +386,7 @@ void AnmCtrlFloat(u16 EntryType)
     if ((EntryType & 7) == 2)
     {
         u16 FrameCount;
-        u16 FrameCount00;
+        u16 Unk;
         
         local int i;
         for (i = 0; i < FrameCount; i++)

--- a/CCSF/CCS_PartStructs.bt
+++ b/CCSF/CCS_PartStructs.bt
@@ -1,0 +1,507 @@
+//------------------------------------------------
+//--- 010 Editor v12.0.1 Binary Template
+//
+//      File: CCS.bt
+//   Authors: HydraBladeZ, Dei
+//   Version: 1.00
+//   Purpose: Parse CCS files
+//  Category: 
+// File Mask: *.ccs
+//  ID Bytes: 46 53 43 43
+//   History: 
+//------------------------------------------------
+
+LittleEndian();
+
+///PartGenerator
+typedef struct{
+    s32 A_offsetInBuffer <format=hex>;           // 0x08
+    local int offsetInBuffer <format=hex> = (A_offsetInBuffer & 0xf0000); //tests
+    s16 PartLife;
+    s16 A_extraFlags;
+    float A;
+    float Velocity;
+    float A;
+    float A;
+    float A;
+    float A;
+    s32 A_typeHighExtra;
+    s16 A_additionalPropertiesLow;
+    s16 A_additionalPropertiesLow;
+    float A;
+    float A;
+    float A;
+    float A;
+    float A;
+    float AlphaMultiply;
+    float A;
+    u32 Element_EffectID <read=ReadChunkNameIndex>;
+    s16 A <format=hex>;
+    s16 A <format=hex>;
+}PartGen_ffff;
+
+typedef struct{
+    u32 Element_EffectID <read=ReadChunkNameIndex>;
+    s16 A <format=hex>;
+    s16 A <format=hex>;
+}PartGen_Extra; // 0x08
+
+typedef struct{
+    s32 A <format=hex>;         // 0x00
+    float PartScale_A <format=hex>;         // 0x06
+    float PartScale_B <format=hex>;         // 0x08
+    float PartScale_C <format=hex>;         // 0x0c
+    float A <format=hex>;         // 0x10
+    u32 Element_EffectID <read=ReadChunkNameIndex>; // 0x14
+    s16 A <format=hex>;         // 0x18
+    s16 A <format=hex>;         // 0x18
+    
+    if (EndPos - FTell() == 22 )
+    {
+        struct PartGen_Extra GenExtra00;
+        struct PartGen_Extra GenExtra01;
+        struct PartGen_Extra GenExtra02;
+    }
+    
+    if (EndPos - FTell() == 24 )
+    {
+        struct PartGen_Extra GenExtra;
+    }
+    
+    if (EndPos - FTell() == 16 )
+    {
+        struct PartGen_Extra GenExtra00;
+        struct PartGen_Extra GenExtra01;
+    }
+    
+    if (EndPos - FTell() == 8 )
+    {
+        struct PartGen_Extra GenExtra;
+    }
+}PartGen_0000; // 0x20
+
+typedef struct{
+    s32 A <format=hex>;                     // 0x00
+    s8  A_particleSubFlags <format=hex>;    // 0x04
+    s8  A_unknownField2 <format=hex>;       // 0x05
+    s16 A_descriptorFlagsHigh <format=hex>; // 0x06
+    s32 A_flagsLowExtra <format=hex>;       // 0x08
+    s32 A_flagsHighExtra;                   // 0x0c
+    s32 A_propertiesLowExtra <format=hex>;  // 0x10
+    u32 Element_EffectID <read=ReadChunkNameIndex>; // 0x14
+    s16 A_typeLowExtra <format=hex>;        // 0x18
+    s16 A_typeLowExtra1 <format=hex>;       // 0x18
+    
+    if (EndPos - FTell() == 22 )
+    {
+        struct PartGen_Extra GenExtra;
+    }
+    
+    if (EndPos - FTell() == 24 )
+    {
+        struct PartGen_Extra GenExtra;
+    }
+    
+    if (EndPos - FTell() == 16 )
+    {
+        struct PartGen_Extra GenExtra;
+    }
+    
+    if (EndPos - FTell() == 8 )
+    {
+        struct PartGen_Extra GenExtra;
+    }
+}PartGen_00fd; // 0x20
+
+
+///PartAnmCtrl
+typedef struct{
+    struct PAC_sub  PartAnmCtrl_Sub;
+}PartAnmCtrl_0001;
+
+typedef struct{
+    struct PAC_sub  PartAnmCtrl_Sub;
+    struct PAC_sub  PartAnmCtrl_Sub;
+}PartAnmCtrl_0002;
+
+typedef struct{
+    struct PAC_sub  PartAnmCtrl_Sub;
+    struct PAC_sub  PartAnmCtrl_Sub;
+    struct PAC_sub  PartAnmCtrl_Sub;
+}PartAnmCtrl_0003;
+
+typedef struct{
+    struct PAC_sub  PartAnmCtrl_Sub;
+    struct PAC_sub  PartAnmCtrl_Sub;
+    struct PAC_sub  PartAnmCtrl_Sub;
+    struct PAC_sub  PartAnmCtrl_Sub;
+}PartAnmCtrl_0004;
+
+typedef struct{
+    struct PAC_sub  PartAnmCtrl_Sub;
+    struct PAC_sub  PartAnmCtrl_Sub;
+    struct PAC_sub  PartAnmCtrl_Sub;
+    struct PAC_sub  PartAnmCtrl_Sub;
+    struct PAC_sub  PartAnmCtrl_Sub;
+}PartAnmCtrl_0005;
+
+typedef struct{
+    struct PAC_sub  PartAnmCtrl_Sub;
+    struct PAC_sub  PartAnmCtrl_Sub;
+    struct PAC_sub  PartAnmCtrl_Sub;
+    struct PAC_sub  PartAnmCtrl_Sub;
+    struct PAC_sub  PartAnmCtrl_Sub;
+    struct PAC_sub  PartAnmCtrl_Sub;
+}PartAnmCtrl_0006;
+
+typedef struct{
+    struct PAC_sub  PartAnmCtrl_Sub;
+    struct PAC_sub  PartAnmCtrl_Sub;
+    struct PAC_sub  PartAnmCtrl_Sub;
+    struct PAC_sub  PartAnmCtrl_Sub;
+    struct PAC_sub  PartAnmCtrl_Sub;
+    struct PAC_sub  PartAnmCtrl_Sub;
+    struct PAC_sub  PartAnmCtrl_Sub;
+    struct PAC_sub  PartAnmCtrl_Sub;
+}PartAnmCtrl_0008;
+
+typedef struct{
+    struct PAC_sub  PartAnmCtrl_Sub;
+    struct PAC_sub  PartAnmCtrl_Sub;
+    struct PAC_sub  PartAnmCtrl_Sub;
+    struct PAC_sub  PartAnmCtrl_Sub;
+    struct PAC_sub  PartAnmCtrl_Sub;
+    struct PAC_sub  PartAnmCtrl_Sub;
+    struct PAC_sub  PartAnmCtrl_Sub;
+    struct PAC_sub  PartAnmCtrl_Sub;
+    struct PAC_sub  PartAnmCtrl_Sub;
+}PartAnmCtrl_0009;
+
+
+typedef struct{
+    u32 A;
+    u32 A;
+    u32 A;
+}PartAnmCtrl_000b;
+
+
+typedef struct{
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+}PartAnmCtrl_0013;
+
+
+typedef struct{
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+}PartAnmCtrl_0015;
+
+
+typedef struct{
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+}PartAnmCtrl_001f;
+
+
+typedef struct{
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+}PartAnmCtrl_0024;
+
+
+typedef struct{
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+}PartAnmCtrl_0029;
+
+
+typedef struct{
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+}PartAnmCtrl_002e;
+
+
+typedef struct{
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+}PartAnmCtrl_0033;
+
+
+typedef struct{
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+}PartAnmCtrl_0036;
+
+
+typedef struct{
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+}PartAnmCtrl_003d;
+
+
+typedef struct{
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+}PartAnmCtrl_003e;
+
+
+typedef struct{
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+}PartAnmCtrl_0042;
+
+
+typedef struct{
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+}PartAnmCtrl_0047;
+
+
+typedef struct{
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+}PartAnmCtrl_0051;
+
+
+typedef struct{
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+}PartAnmCtrl_005b;
+
+
+typedef struct{
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+}PartAnmCtrl_0065;
+
+
+typedef struct{
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+    u32 A;
+}PartAnmCtrl_00ab;

--- a/CCSF/CCS_Particle.bt
+++ b/CCSF/CCS_Particle.bt
@@ -1,0 +1,222 @@
+//------------------------------------------------
+//--- 010 Editor v12.0.1 Binary Template
+//
+//      File: CCS.bt
+//   Authors: HydraBladeZ
+//   Version: 1.00
+//   Purpose: Parse CCS files
+//  Category: 
+// File Mask: *.ccs
+//  ID Bytes: 46 53 43 43
+//   History: 
+//------------------------------------------------
+
+LittleEndian();
+
+//PartGenerator Chunk
+typedef struct
+{
+    u32 ChunkNameIndex <read=ReadChunkNameIndex>;
+    u32 A;
+    u32 Flags <format=hex>;
+    local int Flags0x00 <format=hex> = ((Flags >> 0x00) & 0xf);
+    local int Flags0x04 <format=hex> = ((Flags >> 0x04) & 0xf);
+    local int Flags0x08 <format=hex> = ((Flags >> 0x08) & 0xf);
+    local int Flags0x0c_NumElements  = ((Flags >> 0x0c) & 0xf);
+    local int Flags0x10_NumSubChunks = ((Flags >> 0x10) & 0xf);
+    local int Flags0x14 <format=hex> = ((Flags >> 0x14) & 0xf);
+    local int Flags0x18 <format=hex> = ((Flags >> 0x18) & 0xf);
+    local int Flags0x1c <format=hex> = ((Flags >> 0x1c) & 0xf);
+        local int Flags000 <format=hex> = ((Flags >> 0x14) & 0x1f); //tests
+    
+    local int PartGenSectionSize  = DataSize * 4;
+    local int StartPos = FTell();
+    local int EndPos = StartPos + (PartGenSectionSize - 12);
+    while (FTell() < EndPos)
+    {
+        struct
+        {
+            PartGeneratorTypes Type;
+            FSkip(2);
+            
+            switch (Type)
+            {
+                case PartGenerator_ffff:
+                    struct PartGen_ffff Genffff;
+                break;
+                
+                case PartGenerator_0000:
+                    struct PartGen_0000 Gen0000;
+                break;
+                
+                case PartGenerator_00fd:
+                    struct PartGen_00fd Gen00fd;
+                break;
+                
+                default:
+                    struct
+                        {
+                            u8 Data [EndPos - FTell()];
+                        }SUnknown;
+                break;
+            }
+        }PartGeneratorChunk <read = ReadPartGenChunkType(Type)>;
+    }
+}PGE;
+
+
+//PartAnmCtrl Chunk
+typedef struct
+{
+    u32 ChunkNameIndex <read=ReadChunkNameIndex>;
+    u32 AnimationIndex <read=ReadChunkNameIndex>;
+    
+    local int PartAnmCtrlSectionSize  = DataSize * 4;
+    local int StartPos = FTell();
+    local int EndPos = StartPos + (PartAnmCtrlSectionSize - 8);
+    while (FTell() < EndPos)
+    {
+        struct
+        {
+            PartAnmCtrlTypes Type;
+            FSkip(2);
+            
+            switch (Type)
+            {
+                case PartAnimationCtrl_0001:
+                    struct PartAnmCtrl_0001 PartAnmCtrl0001;
+                break;
+                
+                case PartAnimationCtrl_0002:
+                    struct PartAnmCtrl_0002 PartAnmCtrl0002;
+                break;
+                
+                case PartAnimationCtrl_0003:
+                    struct PartAnmCtrl_0003 PartAnmCtrl0003;
+                break;
+                
+                case PartAnimationCtrl_0004:
+                    struct PartAnmCtrl_0004 PartAnmCtrl0004;
+                break;
+                
+                case PartAnimationCtrl_0005:
+                    struct PartAnmCtrl_0005 PartAnmCtrl0005;
+                break;
+                
+                case PartAnimationCtrl_0006:
+                    struct PartAnmCtrl_0006 PartAnmCtrl0006;
+                break;
+                
+                case PartAnimationCtrl_0008:
+                    struct PartAnmCtrl_0008 PartAnmCtrl0008;
+                break;
+                
+                case PartAnimationCtrl_0009:
+                    struct PartAnmCtrl_0009 PartAnmCtrl0009;
+                break;
+                
+                /*default:
+                    Printf("Unknown PartAnmCtrl (%x) at %x\n", Type, FTell());
+                    struct
+                        {
+                            u8 Data [EndPos - FTell()];
+                        }SUnknown;
+                break;*/
+            }
+        }PartAnmCtrlChunk;
+    }
+    //u32 Data[(DataSize) - 19] <format=hex>;
+}PAC;
+
+typedef struct
+{
+    u32 PartGeneratorID <read=ReadChunkNameIndex>;
+    u32 ObjectIndex <read=ReadChunkNameIndex>;
+    u32 ObjectIndex <read=ReadChunkNameIndex>;
+    u32 A;
+    
+    struct
+    {
+        PartAnmCtrlSubTypes Type;
+        FSkip(2);
+        
+        switch (Type)
+        {
+            case PartAnimationCtrl_000b:
+                struct PartAnmCtrl_000b PartAnmCtrl000b;
+            break;
+                
+            case PartAnimationCtrl_0013:
+                struct PartAnmCtrl_0013 PartAnmCtrl0013;
+            break;
+                
+            case PartAnimationCtrl_0015:
+                struct PartAnmCtrl_0015 PartAnmCtrl0015;
+            break;
+                
+            case PartAnimationCtrl_001f:
+                struct PartAnmCtrl_001f PartAnmCtrl001f;
+            break;
+                
+            case PartAnimationCtrl_0024:
+                struct PartAnmCtrl_0024 PartAnmCtrl0024;
+            break;
+                
+            case PartAnimationCtrl_0029:
+                struct PartAnmCtrl_0029 PartAnmCtrl0029;
+            break;
+                
+            case PartAnimationCtrl_002e:
+                struct PartAnmCtrl_002e PartAnmCtrl002e;
+            break;
+                
+            case PartAnimationCtrl_0033:
+                struct PartAnmCtrl_0033 PartAnmCtrl0033;
+            break;
+                
+            case PartAnimationCtrl_0036:
+                struct PartAnmCtrl_0036 PartAnmCtrl0036;
+            break;
+                
+            case PartAnimationCtrl_003d:
+                struct PartAnmCtrl_003d PartAnmCtrl003d;
+            break;
+                
+            case PartAnimationCtrl_003e:
+                struct PartAnmCtrl_003e PartAnmCtrl003e;
+            break;
+                
+            case PartAnimationCtrl_0042:
+                struct PartAnmCtrl_0042 PartAnmCtrl0042;
+            break;
+                
+            case PartAnimationCtrl_0047:
+                struct PartAnmCtrl_0047 PartAnmCtrl0047;
+            break;
+                
+            case PartAnimationCtrl_0051:
+                struct PartAnmCtrl_0051 PartAnmCtrl0051;
+            break;
+                
+            case PartAnimationCtrl_005b:
+                struct PartAnmCtrl_005b PartAnmCtrl005b;
+            break;
+                
+            case PartAnimationCtrl_0065:
+                struct PartAnmCtrl_0065 PartAnmCtrl0065;
+             break;
+                
+            case PartAnimationCtrl_00ab:
+                struct PartAnmCtrl_00ab PartAnmCtrl00ab;
+             break;
+                
+            /*default:
+                Printf("Unknown PartAnmCtrl (%x) at %x\n", Type, FTell());
+                struct
+                {
+                    u8 Data [4];
+                }SUnknown;
+            break;*/
+        }
+    }PAC_sub_sub;
+}PAC_sub;

--- a/CCSF/CCS_Types.bt
+++ b/CCSF/CCS_Types.bt
@@ -89,7 +89,7 @@ enum <u16> AnimationTypes
     CameraController                = 0x0503,
     AmbientFrame                    = 0x0601,
     DistantLightFrame               = 0x0602,
-    DirectionalLightController      = 0x0603,
+    DistantLightController          = 0x0603,
     DirectLightFrame                = 0x0604,
     //Unknow                        = 0x0605,
     SpotLightFrame                  = 0x0606,

--- a/CCSF/CCS_Types.bt
+++ b/CCSF/CCS_Types.bt
@@ -19,7 +19,7 @@ enum <u16> DataTypes
     StringTable             = 0x0002,
     Null                    = 0x0003,
     Stream                  = 0x0005,
-    Object                  = 0x0100,
+    Object                  = 0x0100, //Obj
     StreamObject            = 0x0101,
     Material                = 0x0200,
     Texture                 = 0x0300,
@@ -49,11 +49,12 @@ enum <u16> DataTypes
     StreamToneShadeParam    = 0x1C00,
     StreamFSBlurParam       = 0x1D00,
     Sprite2Tbl              = 0x1F00,
-    AnimationReference      = 0x2000, //obj2
+    AnimationReference      = 0x2000, //Obj2
     PCM_Audio               = 0x2200,
-    Dynamics                = 0x2300,
+    Dynamics                = 0x2300, //CmpDynamics
     Binary_Blob             = 0x2400,
     //Frame                   = 0xff01
+    
 };
 
 
@@ -72,6 +73,7 @@ enum <u8> TextureTypes
     Indexed8 = 0x13,
     Indexed4 = 0x14,
     DXT1 = 0x87,
+    DXT3 = 0x88,
     DXT5 = 0x89,
 };
 
@@ -89,7 +91,9 @@ enum <u16> AnimationTypes
     DistantLightFrame               = 0x0602,
     DirectionalLightController      = 0x0603,
     DirectLightFrame                = 0x0604,
+    //Unknow                        = 0x0605,
     SpotLightFrame                  = 0x0606,
+    //Unknow                        = 0x0607,
     OmniLightFrame                  = 0x0608,
     OmniLightController             = 0x0609,
     ModelVertexFrame                = 0x0802,
@@ -103,4 +107,46 @@ enum <u16> AnimationTypes
     FBSBlurFrame                    = 0x1d01,
     PCMFrame                        = 0x2201,
     Frame                           = 0xff01
+};
+
+
+enum <u16> PartGeneratorTypes
+{   
+    PartGenerator_ffff              = 0xffff,
+    PartGenerator_0000              = 0x0000,
+    PartGenerator_00fd              = 0x00fd
+    
+};
+
+enum <u16> PartAnmCtrlTypes
+{   
+    PartAnimationCtrl_0001              = 0x0001,
+    PartAnimationCtrl_0002              = 0x0002,
+    PartAnimationCtrl_0003              = 0x0003,
+    PartAnimationCtrl_0004              = 0x0004,
+    PartAnimationCtrl_0005              = 0x0005,
+    PartAnimationCtrl_0006              = 0x0006,
+    PartAnimationCtrl_0008              = 0x0008,
+    PartAnimationCtrl_0009              = 0x0009
+};
+
+enum <u16> PartAnmCtrlSubTypes
+{   
+    PartAnimationCtrl_000b              = 0x000b,   // 12
+    PartAnimationCtrl_0013              = 0x0013,   // 20
+    PartAnimationCtrl_0015              = 0x0015,   // 22
+    PartAnimationCtrl_001f              = 0x001f,   // 32
+    PartAnimationCtrl_0024              = 0x0024,   // 36
+    PartAnimationCtrl_0029              = 0x0029,
+    PartAnimationCtrl_002e              = 0x002e,
+    PartAnimationCtrl_0033              = 0x0033,
+    PartAnimationCtrl_0036              = 0x0036,
+    PartAnimationCtrl_003d              = 0x003d,
+    PartAnimationCtrl_003e              = 0x003e,
+    PartAnimationCtrl_0042              = 0x0042,
+    PartAnimationCtrl_0047              = 0x0047,
+    PartAnimationCtrl_0051              = 0x0051,
+    PartAnimationCtrl_005b              = 0x005b,
+    PartAnimationCtrl_0065              = 0x0065,
+    PartAnimationCtrl_00ab              = 0x00ab    // 172
 };


### PR DESCRIPTION
Added suport: (Mostly complete)
 Effect Chunks

Added very basic support: (Still needs a lot of work):
 PartGenarator Chunks
 PartAnmCtrl Chunks

Updated:
 Model Chunks - Added support for models with tangents and binormals. 
 Texture Chunks - Fixed incorect BXT data size, added DXT3 type.
 Material Chunks - Added additions and fixes for file versions 0x130 and 0x135.
 MaterialCtrl Chunks - Update to handle Chunks with more information.